### PR TITLE
Add 7bit string varint support to pass binary proto tests.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -54,7 +54,21 @@ namespace Mirror
 
         // note: this will throw an ArgumentException if an invalid utf8 string is sent
         // null support, see NetworkWriter
-        public string ReadString() => ReadBoolean() ? reader.ReadString(reader.ReadUInt()) : null;
+        public string ReadString() => ReadBoolean() ? reader.ReadString(Read7BitVarInt()) : null;
+
+        uint Read7BitVarInt()
+        {
+            uint value = 0;
+            int shift = 0;
+            byte b;
+            do
+            {
+                b = reader.ReadByte();
+                value |= (b & 127u) << shift;
+                shift += 7;
+            } while ((b >> 7) != 0 && shift < 32);
+            return value;
+        }
 
         public byte[] ReadBytes(int count)
         {

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -71,7 +71,21 @@ namespace Mirror
             //        should also be null on the client)
             Write(value != null);
             if (value != null)
+            {
+                uint length = (uint) value.Length; //TODO: get byte length not char length
+                Write7BitVarInt(length);
                 writer.WriteString(value);
+            }
+        }
+
+        void Write7BitVarInt(uint value)
+        {
+            while (value >= 128)
+            {
+                writer.WriteByte((byte) (value | 128));
+                value >>= 7;
+            }
+            writer.WriteByte((byte) value);
         }
 
         // for byte arrays with consistent size, where the reader knows how many to read


### PR DESCRIPTION
We still need to make it write the byte length, not the char length, but now only 2 tests fail so, WOOT!